### PR TITLE
Refactor parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ pytest
 
 * Support for FROM instructions with `--platform` specified.
 * Add a `--version` argument.
+* Refactor parsing to preserve more formatting.
 
 
 ### v0.1 (2020-12-02)

--- a/src/dlock/cli.py
+++ b/src/dlock/cli.py
@@ -27,7 +27,7 @@ from typing import Optional, Sequence
 import docker
 
 import dlock
-from dlock.io import read_dockerfile, write_dockerfile
+from dlock.io import Dockerfile
 from dlock.output import Log
 from dlock.processing import DockerfileProcessor
 from dlock.registry import DockerResolver, Resolver
@@ -100,7 +100,7 @@ def run(
     processor = DockerfileProcessor(resolver, log=log, upgrade=options.upgrade)
     for file in options.files:
         try:
-            dockerfile = read_dockerfile(file)
+            dockerfile = Dockerfile.read(file)
         except OSError as e:
             log(1, f"{file}: failed to read file: {e.strerror}")
             sys.exit(1)
@@ -111,7 +111,7 @@ def run(
             log(1, f"{file}: dry run, changes not saved")
         else:
             try:
-                write_dockerfile(new_dockerfile, file)
+                new_dockerfile.write()
             except OSError as e:
                 log(1, f"{file}: failed write file: {e.strerror}")
                 sys.exit(1)

--- a/src/dlock/cli.py
+++ b/src/dlock/cli.py
@@ -27,8 +27,8 @@ from typing import Optional, Sequence
 import docker
 
 import dlock
+from dlock.io import read_dockerfile, write_dockerfile
 from dlock.output import Log
-from dlock.parsing import read_dockerfile, write_dockerfile
 from dlock.processing import DockerfileProcessor
 from dlock.registry import DockerResolver, Resolver
 

--- a/src/dlock/io.py
+++ b/src/dlock/io.py
@@ -1,0 +1,43 @@
+# Copyright 2020 Akamai Technologies, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import dataclasses
+from typing import List, Optional
+
+
+@dataclasses.dataclass(frozen=True)
+class Dockerfile:
+    """
+    Dockerfile content.
+    """
+
+    lines: List[str]
+    name: Optional[str] = None
+
+
+def read_dockerfile(path: str) -> Dockerfile:
+    """
+    Read Dockerfile from the given file-system path.
+    """
+    with open(path) as f:
+        return Dockerfile(f.readlines(), name=path)
+
+
+def write_dockerfile(dockerfile: Dockerfile, path: str) -> None:
+    """
+    Write Dockerfile to the given file-system path.
+    """
+    with open(path, "w") as f:
+        f.writelines(dockerfile.lines)

--- a/src/dlock/io.py
+++ b/src/dlock/io.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import List, Optional
+from typing import List
 
 
 @dataclasses.dataclass(frozen=True)
@@ -24,20 +24,19 @@ class Dockerfile:
     """
 
     lines: List[str]
-    name: Optional[str] = None
+    name: str = "Dockerfile"
 
+    @classmethod
+    def read(cls, path: str) -> Dockerfile:
+        """
+        Read Dockerfile from the given file-system path.
+        """
+        with open(path) as f:
+            return cls(f.readlines(), name=path)
 
-def read_dockerfile(path: str) -> Dockerfile:
-    """
-    Read Dockerfile from the given file-system path.
-    """
-    with open(path) as f:
-        return Dockerfile(f.readlines(), name=path)
-
-
-def write_dockerfile(dockerfile: Dockerfile, path: str) -> None:
-    """
-    Write Dockerfile to the given file-system path.
-    """
-    with open(path, "w") as f:
-        f.writelines(dockerfile.lines)
+    def write(self) -> None:
+        """
+        Write Dockerfile to the given file-system path.
+        """
+        with open(self.name, "w") as f:
+            f.writelines(self.lines)

--- a/src/dlock/parsing.py
+++ b/src/dlock/parsing.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Dockerfile parser
 
@@ -19,12 +18,13 @@ Minimal necessary Dockerfile parser which looks
 only for instructions that can reference Docker images.
 Preserves whitespace and formatting where possible.
 """
+
 from __future__ import annotations
 
 import dataclasses
 import itertools
 from abc import ABCMeta, abstractmethod
-from typing import Iterable, List, Optional
+from typing import Iterable, Optional
 
 # Parsing is done in two steps:
 #
@@ -193,31 +193,3 @@ def _parse_tokens(tokens: Iterable[str]) -> Iterable[Instruction]:
 def parse_dockerfile(lines: Iterable[str]) -> Iterable[Instruction]:
     tokens = tokenize_dockerfile(lines)
     return _parse_tokens(tokens)
-
-
-@dataclasses.dataclass(frozen=True)
-class Dockerfile:
-    """
-    Parsed Dockerfile.
-
-    Holds a list of parsed instructions.
-    """
-
-    lines: List[str]
-    name: Optional[str] = None
-
-
-def read_dockerfile(path: str) -> Dockerfile:
-    """
-    Read Dockerfile from the given file-system path.
-    """
-    with open(path) as f:
-        return Dockerfile(f.readlines(), name=path)
-
-
-def write_dockerfile(dockerfile: Dockerfile, path: str) -> None:
-    """
-    Write Dockerfile to the given file-system path.
-    """
-    with open(path, "w") as f:
-        f.writelines(dockerfile.lines)

--- a/src/dlock/parsing.py
+++ b/src/dlock/parsing.py
@@ -95,22 +95,21 @@ def tokenize_dockerfile(lines: Iterable[str]) -> Iterable[Token]:
 
     Each token is one instruction, comment, or an empty line.
     """
-    value = ""
+    token_value = ""
     for line in itertools.chain(lines, [""]):
-        is_comment = line and _is_comment_or_blank(line)
-        if not is_comment and line.rstrip().endswith("\\"):
-            # Backslash is a line continuation character.
-            is_complete = False
-        elif is_comment and value:
-            # Comments are removed, so they do not terminate an expression.
-            is_complete = False
-        else:
-            # Expression has to be complete if continuation is not indicated.
+        if not line:
+            # End of file marker
             is_complete = True
-        value += line
-        if is_complete and value:
-            yield Token(value)
-            value = ""
+        elif _is_comment_or_blank(line):
+            # Comments are removed, so they do not terminate an expression.
+            is_complete = not token_value
+        else:
+            # Backslash is a line continuation character.
+            is_complete = not line.rstrip().endswith("\\")
+        token_value += line
+        if is_complete and token_value:
+            yield Token(token_value)
+            token_value = ""
 
 
 class InvalidInstruction(Exception):

--- a/src/dlock/parsing.py
+++ b/src/dlock/parsing.py
@@ -225,8 +225,11 @@ class Dockerfile:
         instructions = list(_parse_tokens(tokens))
         return cls(instructions, name=name)
 
+    def serialize(self) -> List[str]:
+        return list(map(str, self.instructions))
+
     def to_string(self) -> str:
-        return "".join(map(str, self.instructions))
+        return "".join(self.serialize())
 
     def with_line_numbers(self) -> Iterable[Tuple[int, Instruction]]:
         line_number = 1
@@ -248,5 +251,4 @@ def write_dockerfile(dockerfile: Dockerfile, path: str) -> None:
     Write Dockerfile to the given file-system path.
     """
     with open(path, "w") as f:
-        for instruction in dockerfile.instructions:
-            f.write(instruction.to_string())
+        f.writelines(dockerfile.serialize())

--- a/src/dlock/processing.py
+++ b/src/dlock/processing.py
@@ -122,7 +122,7 @@ class DockerfileProcessor:
         state = ProcessingState()
         if dockerfile.name is not None:
             state.file_name = dockerfile.name
-        new_dockerfile = self._process_dockerfile(state, dockerfile)
+        new_lines = self._process_lines(state, dockerfile.lines)
 
         # Report summary of changes.
         # To ensure that at least one line of output is generated,
@@ -140,35 +140,33 @@ class DockerfileProcessor:
         if state.keep_count:
             count = _count_images(state.keep_count)
             self._log(1, f"{state.file_name}: {count} outdated, not upgraded")
-        return new_dockerfile
+        return Dockerfile(new_lines, name=dockerfile.name)
 
-    def _process_dockerfile(
-        self, state: ProcessingState, dockerfile: Dockerfile
-    ) -> Dockerfile:
-        new_instructions: List[Instruction] = []
-        instructions = parse_dockerfile(dockerfile.lines)
-        for instruction in instructions:
-            new_instruction = self._process_instruction(state, instruction)
-            new_instructions.append(new_instruction)
-            state.line_number += instruction.to_string().count("\n")
-        return Dockerfile(
-            [i.to_string() for i in new_instructions], name=dockerfile.name
-        )
+    def _process_lines(self, state: ProcessingState, lines: List[str]) -> List[str]:
+        new_lines = []
+        for node in parse_dockerfile(lines):
+            state.line_number = node.lineno
+            new_inst = self._process_instruction(state, node.inst)
+            # If an instruction was not updated, return its original
+            # text value to preserve formatting details.
+            code = node.orig if new_inst == node.inst else new_inst.to_string()
+            new_lines += code.splitlines(keepends=True)
+        return new_lines
 
     def _process_instruction(
-        self, state: ProcessingState, instruction: Instruction
+        self, state: ProcessingState, inst: Instruction
     ) -> Instruction:
-        if isinstance(instruction, FromInstruction):
-            return self._process_from_instruction(state, instruction)
-        return instruction
+        if isinstance(inst, FromInstruction):
+            return self._process_from_instruction(state, inst)
+        return inst
 
     def _process_from_instruction(
-        self, state: ProcessingState, instruction: FromInstruction
+        self, state: ProcessingState, inst: FromInstruction
     ) -> Instruction:
-        new_base = self._process_ref(state, instruction.base)
-        if instruction.name is not None:
-            state.stages.append(instruction.name)
-        return instruction.replace(base=new_base)
+        new_base = self._process_ref(state, inst.base)
+        if inst.name is not None:
+            state.stages.append(inst.name)
+        return inst.replace(base=new_base)
 
     def _process_ref(self, state: ProcessingState, ref: str) -> str:
         position = f"{state.position}: image {ref}"

--- a/src/dlock/processing.py
+++ b/src/dlock/processing.py
@@ -20,8 +20,9 @@ from __future__ import annotations
 import dataclasses
 from typing import List, Optional
 
+from dlock.io import Dockerfile
 from dlock.output import Log
-from dlock.parsing import Dockerfile, FromInstruction, Instruction, parse_dockerfile
+from dlock.parsing import FromInstruction, Instruction, parse_dockerfile
 from dlock.registry import Resolver
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,16 +1,16 @@
-from dlock.io import Dockerfile, read_dockerfile, write_dockerfile
+from dlock.io import Dockerfile
 
 
-def test_read_dockerfile(resolver, tmp_path):
-    path = tmp_path / "Dockerfile"
-    path.write_text("FROM debian\n")
-    dockerfile = read_dockerfile(path)
-    assert dockerfile.name == path
-    assert dockerfile.lines == ["FROM debian\n"]
+class TestDockerfile:
+    def test_read_dockerfile(self, resolver, tmp_path):
+        path = tmp_path / "Dockerfile"
+        path.write_text("FROM debian\n")
+        dockerfile = Dockerfile.read(path)
+        assert dockerfile.name == path
+        assert dockerfile.lines == ["FROM debian\n"]
 
-
-def test_write_dockerfile(tmp_path):
-    path = tmp_path / "Dockerfile"
-    dockerfile = Dockerfile(["FROM debian\n"], name=path)
-    write_dockerfile(dockerfile, path=dockerfile.name)
-    assert path.read_text() == "FROM debian\n"
+    def test_write_dockerfile(self, tmp_path):
+        path = tmp_path / "Dockerfile"
+        dockerfile = Dockerfile(["FROM debian\n"], name=path)
+        dockerfile.write()
+        assert path.read_text() == "FROM debian\n"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,16 @@
+from dlock.io import Dockerfile, read_dockerfile, write_dockerfile
+
+
+def test_read_dockerfile(resolver, tmp_path):
+    path = tmp_path / "Dockerfile"
+    path.write_text("FROM debian\n")
+    dockerfile = read_dockerfile(path)
+    assert dockerfile.name == path
+    assert dockerfile.lines == ["FROM debian\n"]
+
+
+def test_write_dockerfile(tmp_path):
+    path = tmp_path / "Dockerfile"
+    dockerfile = Dockerfile(["FROM debian\n"], name=path)
+    write_dockerfile(dockerfile, path=dockerfile.name)
+    assert path.read_text() == "FROM debian\n"

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -89,17 +89,17 @@ class TestTokenizeDockerfile:
         """Empty docker file."""
         assert list(tokenize_dockerfile([])) == []
 
-    def test_tokenize_one_line_wo_traling_newline(self):
+    def test_tokenize_one_line_wo_trailing_newline(self):
         """Dockerfile with one line only, no new line at the end of file."""
         lines = ["# Comment"]
         assert list(tokenize_dockerfile(lines)) == [Token("# Comment")]
 
-    def test_tokenize_one_line_w_traling_newline(self):
+    def test_tokenize_one_line_w_trailing_newline(self):
         """Dockerfile with one line only, with new line at the end of file."""
         lines = ["# Comment\n"]
         assert list(tokenize_dockerfile(lines)) == [Token("# Comment\n")]
 
-    def test_tokenize_multiple_lines_wo_traling_newline(self):
+    def test_tokenize_multiple_lines_wo_trailing_newline(self):
         """Dockerfile with multiple lines, no new line at the end of file."""
         lines = ["# Comment 1\n", "# Comment 2"]
         assert list(tokenize_dockerfile(lines)) == [
@@ -107,7 +107,7 @@ class TestTokenizeDockerfile:
             Token("# Comment 2"),
         ]
 
-    def test_tokenize_multiple_lines_w_traling_newline(self):
+    def test_tokenize_multiple_lines_w_trailing_newline(self):
         """Dockerfile with multiple lines, with new line at the end of file."""
         lines = ["# Comment 1\n", "# Comment 2\n"]
         assert list(tokenize_dockerfile(lines)) == [
@@ -180,7 +180,18 @@ class TestTokenizeDockerfile:
             Token("CMD echo \\\n  'hello world'\n"),
         ]
 
-    def test_tokenize_trailing_slash_at_list_line(self):
+    def test_tokenize_trailing_slash_followed_by_empty_line(self):
+        """"Empty line as continuation is deprecated but works."""
+        lines = [
+            "CMD echo \\\n",
+            "\n",
+            "  'hello world'\n",
+        ]
+        assert list(tokenize_dockerfile(lines)) == [
+            Token("CMD echo \\\n\n  'hello world'\n"),
+        ]
+
+    def test_tokenize_trailing_slash_at_last_line(self):
         """"Backslash is at the last line is valid."""
         lines = [
             "CMD echo \\\n",
@@ -193,7 +204,8 @@ class TestTokenizeDockerfile:
         """Comments can be included in multi-line instructions."""
         lines = [
             "CMD echo \\\n",
-            "  # Comment\n" "  'hello world'\n",
+            "  # Comment\n",
+            "  'hello world'\n",
         ]
         assert list(tokenize_dockerfile(lines)) == [
             Token("CMD echo \\\n  # Comment\n  'hello world'\n"),

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -285,26 +285,26 @@ class TestParseDockerfile:
 
     def test_no_line(self):
         """Empty Dockerfile is parsed."""
-        instructions = parse_dockerfile([])
-        assert list(instructions) == []
+        nodes = parse_dockerfile([])
+        assert list(nodes) == []
 
     def test_one_line(self):
         """Dockerfile with one line only is parsed."""
-        instructions = parse_dockerfile(["# Comment\n"])
-        assert list(instructions) == [GenericInstruction("# Comment\n")]
+        nodes = parse_dockerfile(["# Comment\n"])
+        assert [n.inst for n in nodes] == [GenericInstruction("# Comment\n")]
 
     def test_multiple_lines(self):
         """Dockerfile with multiple lines is parsed."""
-        instructions = parse_dockerfile(["# Comment 1\n", "# Comment 2\n"])
-        assert list(instructions) == [
+        nodes = parse_dockerfile(["# Comment 1\n", "# Comment 2\n"])
+        assert [n.inst for n in nodes] == [
             GenericInstruction("# Comment 1\n"),
             GenericInstruction("# Comment 2\n"),
         ]
 
     def test_parse_from(self):
         """FROM instruction is parsed."""
-        instructions = parse_dockerfile(["FROM debian"])
-        assert list(instructions) == [FromInstruction("debian")]
+        nodes = parse_dockerfile(["FROM debian"])
+        assert [n.inst for n in nodes] == [FromInstruction("debian")]
 
     def test_parse_from_inst_invalid(self):
         """FROM instruction is not parsed if not valid."""
@@ -322,5 +322,5 @@ class TestParseDockerfile:
     )
     def test_parse_generic_instructions(self, value):
         """Most instruction are treated as unparsed strings."""
-        instructions = parse_dockerfile([value])
-        assert list(instructions) == [GenericInstruction(value)]
+        nodes = parse_dockerfile([value])
+        assert [n.inst for n in nodes] == [GenericInstruction(value)]

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -15,16 +15,13 @@
 import pytest
 
 from dlock.parsing import (
-    Dockerfile,
     FromInstruction,
     GenericInstruction,
     InvalidInstruction,
     get_token_cmd,
     get_token_code,
     parse_dockerfile,
-    read_dockerfile,
     tokenize_dockerfile,
-    write_dockerfile,
 )
 
 
@@ -327,18 +324,3 @@ class TestParseDockerfile:
         """Most instruction are treated as unparsed strings."""
         instructions = parse_dockerfile([value])
         assert list(instructions) == [GenericInstruction(value)]
-
-
-def test_read_dockerfile(resolver, tmp_path):
-    path = tmp_path / "Dockerfile"
-    path.write_text("FROM debian\n")
-    dockerfile = read_dockerfile(path)
-    assert dockerfile.name == path
-    assert dockerfile.lines == ["FROM debian\n"]
-
-
-def test_write_dockerfile(tmp_path):
-    path = tmp_path / "Dockerfile"
-    dockerfile = Dockerfile(["FROM debian\n"], name=path)
-    write_dockerfile(dockerfile, path=dockerfile.name)
-    assert path.read_text() == "FROM debian\n"

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -20,7 +20,6 @@ from dlock.parsing import (
     GenericInstruction,
     InvalidInstruction,
     Token,
-    parse_dockerfile,
     read_dockerfile,
     tokenize_dockerfile,
     write_dockerfile,
@@ -306,22 +305,22 @@ class TestDockerfile:
 
 class TestParseDockerfile:
     """
-    Tests the parse_dockerfile function.
+    Tests the Dockerfile.parse method.
     """
 
     def test_no_line(self):
         """Empty Dockerfile is parsed."""
-        dockerfile = parse_dockerfile([])
+        dockerfile = Dockerfile.parse([])
         assert dockerfile.instructions == []
 
     def test_one_line(self):
         """Dockerfile with one line only is parsed."""
-        dockerfile = parse_dockerfile(["# Comment\n"])
+        dockerfile = Dockerfile.parse(["# Comment\n"])
         assert dockerfile.instructions == [GenericInstruction("# Comment\n")]
 
     def test_multiple_lines(self):
         """Dockerfile with multiple lines is parsed."""
-        dockerfile = parse_dockerfile(["# Comment 1\n", "# Comment 2\n"])
+        dockerfile = Dockerfile.parse(["# Comment 1\n", "# Comment 2\n"])
         assert dockerfile.instructions == [
             GenericInstruction("# Comment 1\n"),
             GenericInstruction("# Comment 2\n"),
@@ -329,30 +328,30 @@ class TestParseDockerfile:
 
     def test_parse_from_inst_wo_name(self):
         """FROM instruction without name is parsed."""
-        dockerfile = parse_dockerfile(["FROM debian"])
+        dockerfile = Dockerfile.parse(["FROM debian"])
         assert dockerfile.instructions == [FromInstruction("debian")]
 
     def test_parse_from_inst_w_name(self):
         """FROM instruction with name is parsed."""
-        dockerfile = parse_dockerfile(["FROM debian AS base"])
+        dockerfile = Dockerfile.parse(["FROM debian AS base"])
         assert dockerfile.instructions == [FromInstruction("debian", "base")]
 
     def test_parse_from_inst_w_platform(self):
         """FROM instruction with platform is parsed."""
-        dockerfile = parse_dockerfile(["FROM --platform=linux/amd64 debian"])
+        dockerfile = Dockerfile.parse(["FROM --platform=linux/amd64 debian"])
         assert dockerfile.instructions == [
             FromInstruction("debian", platform="linux/amd64")
         ]
 
     def test_parse_from_inst_not_formatted(self):
         """FROM instruction is parsed even if not properly formatted."""
-        dockerfile = parse_dockerfile(["From    debian As base"])
+        dockerfile = Dockerfile.parse(["From    debian As base"])
         assert dockerfile.instructions == [FromInstruction("debian", "base")]
 
     def test_parse_from_inst_invalid(self):
         """FROM instruction is not parsed if not valid."""
         with pytest.raises(InvalidInstruction):
-            parse_dockerfile(["FROM"])
+            Dockerfile.parse(["FROM"])
 
     @pytest.mark.parametrize(
         "value",
@@ -365,7 +364,7 @@ class TestParseDockerfile:
     )
     def test_parse_generic_instructions(self, value):
         """Most instruction are treated as unparsed strings."""
-        dockerfile = parse_dockerfile([value])
+        dockerfile = Dockerfile.parse([value])
         assert dockerfile.instructions == [GenericInstruction(value)]
 
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -269,7 +269,7 @@ class TestFromInstruction:
         inst = FromInstruction("debian", platform="linux/amd64")
         assert str(inst) == "FROM --platform=linux/amd64 debian\n"
 
-    def test_to_string_w_name_and_plarform(self):
+    def test_to_string_w_name_and_platform(self):
         inst = FromInstruction("debian", "base", platform="linux/amd64")
         assert str(inst) == "FROM --platform=linux/amd64 debian AS base\n"
 
@@ -336,27 +336,10 @@ class TestParseDockerfile:
             GenericInstruction("# Comment 2\n"),
         ]
 
-    def test_parse_from_inst_wo_name(self):
-        """FROM instruction without name is parsed."""
+    def test_parse_from(self):
+        """FROM instruction is parsed."""
         dockerfile = Dockerfile.parse(["FROM debian"])
         assert dockerfile.instructions == [FromInstruction("debian")]
-
-    def test_parse_from_inst_w_name(self):
-        """FROM instruction with name is parsed."""
-        dockerfile = Dockerfile.parse(["FROM debian AS base"])
-        assert dockerfile.instructions == [FromInstruction("debian", "base")]
-
-    def test_parse_from_inst_w_platform(self):
-        """FROM instruction with platform is parsed."""
-        dockerfile = Dockerfile.parse(["FROM --platform=linux/amd64 debian"])
-        assert dockerfile.instructions == [
-            FromInstruction("debian", platform="linux/amd64")
-        ]
-
-    def test_parse_from_inst_not_formatted(self):
-        """FROM instruction is parsed even if not properly formatted."""
-        dockerfile = Dockerfile.parse(["From    debian As base"])
-        assert dockerfile.instructions == [FromInstruction("debian", "base")]
 
     def test_parse_from_inst_invalid(self):
         """FROM instruction is not parsed if not valid."""

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -16,8 +16,8 @@ import io
 
 import pytest
 
+from dlock.io import Dockerfile
 from dlock.output import Log
-from dlock.parsing import Dockerfile
 from dlock.processing import DockerfileProcessor, Image
 
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -64,13 +64,13 @@ class TestDockerfileProcessor:
     def test_from(self, resolver, upgrade):
         """FROM instruction is locked."""
         processor = DockerfileProcessor(resolver, upgrade=upgrade)
-        dockerfile = Dockerfile.parse(
+        dockerfile = Dockerfile(
             [
                 "FROM ubuntu\n",
                 "CMD echo 'hello world'\n",
             ]
         )
-        assert processor.update_dockerfile(dockerfile).serialize() == [
+        assert processor.update_dockerfile(dockerfile).lines == [
             "FROM ubuntu@sha256:7804\n",
             "CMD echo 'hello world'\n",
         ]
@@ -79,13 +79,13 @@ class TestDockerfileProcessor:
     def test_from_w_name(self, resolver, upgrade):
         """FROM instruction with name is locked."""
         processor = DockerfileProcessor(resolver, upgrade=upgrade)
-        dockerfile = Dockerfile.parse(
+        dockerfile = Dockerfile(
             [
                 "FROM ubuntu AS runtime\n",
                 "CMD echo 'hello world'\n",
             ]
         )
-        assert processor.update_dockerfile(dockerfile).serialize() == [
+        assert processor.update_dockerfile(dockerfile).lines == [
             "FROM ubuntu@sha256:7804 AS runtime\n",
             "CMD echo 'hello world'\n",
         ]
@@ -94,13 +94,13 @@ class TestDockerfileProcessor:
     def test_from_w_platform(self, resolver, upgrade):
         """FROM instruction with name is locked."""
         processor = DockerfileProcessor(resolver, upgrade=upgrade)
-        dockerfile = Dockerfile.parse(
+        dockerfile = Dockerfile(
             [
                 "FROM --platform=linux/amd64 ubuntu\n",
                 "CMD echo 'hello world'\n",
             ]
         )
-        assert processor.update_dockerfile(dockerfile).serialize() == [
+        assert processor.update_dockerfile(dockerfile).lines == [
             "FROM --platform=linux/amd64 ubuntu@sha256:7804\n",
             "CMD echo 'hello world'\n",
         ]
@@ -109,13 +109,13 @@ class TestDockerfileProcessor:
     def test_from_w_tag(self, resolver, upgrade):
         """FROM instruction with tag is locked."""
         processor = DockerfileProcessor(resolver, upgrade=upgrade)
-        dockerfile = Dockerfile.parse(
+        dockerfile = Dockerfile(
             [
                 "FROM ubuntu:latest\n",
                 "CMD echo 'hello world'\n",
             ]
         )
-        assert processor.update_dockerfile(dockerfile).serialize() == [
+        assert processor.update_dockerfile(dockerfile).lines == [
             "FROM ubuntu:latest@sha256:abfc\n",
             "CMD echo 'hello world'\n",
         ]
@@ -123,13 +123,13 @@ class TestDockerfileProcessor:
     def test_from_w_digest_upgrade_false(self, resolver):
         """Existing digest not is upgraded by default."""
         processor = DockerfileProcessor(resolver)
-        dockerfile = Dockerfile.parse(
+        dockerfile = Dockerfile(
             [
                 "FROM ubuntu@sha256:xxxx\n",
                 "CMD echo 'hello world'\n",
             ]
         )
-        assert processor.update_dockerfile(dockerfile).serialize() == [
+        assert processor.update_dockerfile(dockerfile).lines == [
             "FROM ubuntu@sha256:xxxx\n",
             "CMD echo 'hello world'\n",
         ]
@@ -137,13 +137,13 @@ class TestDockerfileProcessor:
     def test_from_w_digest_upgrade_true(self, resolver):
         """Existing digest is upgraded on request."""
         processor = DockerfileProcessor(resolver, upgrade=True)
-        dockerfile = Dockerfile.parse(
+        dockerfile = Dockerfile(
             [
                 "FROM ubuntu@sha256:xxxx\n",
                 "CMD echo 'hello world'\n",
             ]
         )
-        assert processor.update_dockerfile(dockerfile).serialize() == [
+        assert processor.update_dockerfile(dockerfile).lines == [
             "FROM ubuntu@sha256:7804\n",
             "CMD echo 'hello world'\n",
         ]
@@ -151,13 +151,13 @@ class TestDockerfileProcessor:
     def test_from_w_tag_and_digest_upgrade_false(self, resolver):
         """Tag with digest is not upgrade by default."""
         processor = DockerfileProcessor(resolver)
-        dockerfile = Dockerfile.parse(
+        dockerfile = Dockerfile(
             [
                 "FROM ubuntu:latest@sha256:xxxx\n",
                 "CMD echo 'hello world'\n",
             ]
         )
-        assert processor.update_dockerfile(dockerfile).serialize() == [
+        assert processor.update_dockerfile(dockerfile).lines == [
             "FROM ubuntu:latest@sha256:xxxx\n",
             "CMD echo 'hello world'\n",
         ]
@@ -165,13 +165,13 @@ class TestDockerfileProcessor:
     def test_from_w_tag_and_digest_upgrade_true(self, resolver):
         """Tag with digest is upgraded on request."""
         processor = DockerfileProcessor(resolver, upgrade=True)
-        dockerfile = Dockerfile.parse(
+        dockerfile = Dockerfile(
             [
                 "FROM ubuntu:latest@sha256:xxxx\n",
                 "CMD echo 'hello world'\n",
             ]
         )
-        assert processor.update_dockerfile(dockerfile).serialize() == [
+        assert processor.update_dockerfile(dockerfile).lines == [
             "FROM ubuntu:latest@sha256:abfc\n",
             "CMD echo 'hello world'\n",
         ]
@@ -179,14 +179,14 @@ class TestDockerfileProcessor:
     def test_from_with_arg(self, resolver):
         """Name with variable is not locked."""
         processor = DockerfileProcessor(resolver)
-        dockerfile = Dockerfile.parse(
+        dockerfile = Dockerfile(
             [
                 "ARG VERSION=latest\n",
                 "FROM ubuntu:${VERSION}\n",
                 "CMD echo 'hello world'\n",
             ]
         )
-        assert processor.update_dockerfile(dockerfile).serialize() == [
+        assert processor.update_dockerfile(dockerfile).lines == [
             "ARG VERSION=latest\n",
             "FROM ubuntu:${VERSION}\n",
             "CMD echo 'hello world'\n",
@@ -195,26 +195,26 @@ class TestDockerfileProcessor:
     def test_from_scratch(self, resolver):
         """Scratch is not a real image."""
         processor = DockerfileProcessor(resolver)
-        dockerfile = Dockerfile.parse(
+        dockerfile = Dockerfile(
             [
                 "FROM scratch\n",
             ]
         )
-        assert processor.update_dockerfile(dockerfile).serialize() == [
+        assert processor.update_dockerfile(dockerfile).lines == [
             "FROM scratch\n",
         ]
 
     def test_multi_stage(self, resolver):
         """Name of previous state is not locked."""
         processor = DockerfileProcessor(resolver)
-        dockerfile = Dockerfile.parse(
+        dockerfile = Dockerfile(
             [
                 "FROM ubuntu AS base\n",
                 "FROM base\n",
                 "CMD echo 'hello world'\n",
             ]
         )
-        assert processor.update_dockerfile(dockerfile).serialize() == [
+        assert processor.update_dockerfile(dockerfile).lines == [
             "FROM ubuntu@sha256:7804 AS base\n",
             "FROM base\n",
             "CMD echo 'hello world'\n",
@@ -223,7 +223,7 @@ class TestDockerfileProcessor:
     def test_output_new_image_upgrade_false(self, resolver):
         output = io.StringIO()
         processor = DockerfileProcessor(resolver, log=Log(output, verbosity=5))
-        dockerfile = Dockerfile.parse(["FROM ubuntu"], name="Dockerfile")
+        dockerfile = Dockerfile(["FROM ubuntu"], name="Dockerfile")
         processor.update_dockerfile(dockerfile)
         assert output.getvalue() == (
             "Dockerfile, line 1: image ubuntu: locked to digest sha256:7804\n"
@@ -233,7 +233,7 @@ class TestDockerfileProcessor:
     def test_output_outdated_image_upgrade_false(self, resolver):
         output = io.StringIO()
         processor = DockerfileProcessor(resolver, log=Log(output, verbosity=5))
-        dockerfile = Dockerfile.parse(["FROM ubuntu@sha256:xxx"], name="Dockerfile")
+        dockerfile = Dockerfile(["FROM ubuntu@sha256:xxx"], name="Dockerfile")
         processor.update_dockerfile(dockerfile)
         assert output.getvalue() == (
             "Dockerfile, line 1: image ubuntu@sha256:xxx: outdated, not upgraded\n"
@@ -244,7 +244,7 @@ class TestDockerfileProcessor:
     def test_output_recent_image_upgrade_false(self, resolver):
         output = io.StringIO()
         processor = DockerfileProcessor(resolver, log=Log(output, verbosity=5))
-        dockerfile = Dockerfile.parse(["FROM ubuntu@sha256:7804"], name="Dockerfile")
+        dockerfile = Dockerfile(["FROM ubuntu@sha256:7804"], name="Dockerfile")
         processor.update_dockerfile(dockerfile)
         assert output.getvalue() == (
             "Dockerfile, line 1: image ubuntu@sha256:7804: up to date\n"
@@ -257,7 +257,7 @@ class TestDockerfileProcessor:
         processor = DockerfileProcessor(
             resolver, upgrade=True, log=Log(output, verbosity=5)
         )
-        dockerfile = Dockerfile.parse(["FROM ubuntu"], name="Dockerfile")
+        dockerfile = Dockerfile(["FROM ubuntu"], name="Dockerfile")
         processor.update_dockerfile(dockerfile)
         assert output.getvalue() == (
             "Dockerfile, line 1: image ubuntu: locked to digest sha256:7804\n"
@@ -270,7 +270,7 @@ class TestDockerfileProcessor:
         processor = DockerfileProcessor(
             resolver, upgrade=True, log=Log(output, verbosity=5)
         )
-        dockerfile = Dockerfile.parse(["FROM ubuntu@sha256:xxx"], name="Dockerfile")
+        dockerfile = Dockerfile(["FROM ubuntu@sha256:xxx"], name="Dockerfile")
         processor.update_dockerfile(dockerfile)
         assert output.getvalue() == (
             "Dockerfile, line 1: image ubuntu@sha256:xxx:"
@@ -283,7 +283,7 @@ class TestDockerfileProcessor:
         processor = DockerfileProcessor(
             resolver, upgrade=True, log=Log(output, verbosity=5)
         )
-        dockerfile = Dockerfile.parse(["FROM ubuntu@sha256:7804"], name="Dockerfile")
+        dockerfile = Dockerfile(["FROM ubuntu@sha256:7804"], name="Dockerfile")
         processor.update_dockerfile(dockerfile)
         assert output.getvalue() == (
             "Dockerfile, line 1: image ubuntu@sha256:7804: up to date\n"

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -223,7 +223,7 @@ class TestDockerfileProcessor:
     def test_output_new_image_upgrade_false(self, resolver):
         output = io.StringIO()
         processor = DockerfileProcessor(resolver, log=Log(output, verbosity=5))
-        dockerfile = Dockerfile(["FROM ubuntu"], name="Dockerfile")
+        dockerfile = Dockerfile(["FROM ubuntu"])
         processor.update_dockerfile(dockerfile)
         assert output.getvalue() == (
             "Dockerfile, line 1: image ubuntu: locked to digest sha256:7804\n"
@@ -233,7 +233,7 @@ class TestDockerfileProcessor:
     def test_output_outdated_image_upgrade_false(self, resolver):
         output = io.StringIO()
         processor = DockerfileProcessor(resolver, log=Log(output, verbosity=5))
-        dockerfile = Dockerfile(["FROM ubuntu@sha256:xxx"], name="Dockerfile")
+        dockerfile = Dockerfile(["FROM ubuntu@sha256:xxx"])
         processor.update_dockerfile(dockerfile)
         assert output.getvalue() == (
             "Dockerfile, line 1: image ubuntu@sha256:xxx: outdated, not upgraded\n"
@@ -244,7 +244,7 @@ class TestDockerfileProcessor:
     def test_output_recent_image_upgrade_false(self, resolver):
         output = io.StringIO()
         processor = DockerfileProcessor(resolver, log=Log(output, verbosity=5))
-        dockerfile = Dockerfile(["FROM ubuntu@sha256:7804"], name="Dockerfile")
+        dockerfile = Dockerfile(["FROM ubuntu@sha256:7804"])
         processor.update_dockerfile(dockerfile)
         assert output.getvalue() == (
             "Dockerfile, line 1: image ubuntu@sha256:7804: up to date\n"
@@ -257,7 +257,7 @@ class TestDockerfileProcessor:
         processor = DockerfileProcessor(
             resolver, upgrade=True, log=Log(output, verbosity=5)
         )
-        dockerfile = Dockerfile(["FROM ubuntu"], name="Dockerfile")
+        dockerfile = Dockerfile(["FROM ubuntu"])
         processor.update_dockerfile(dockerfile)
         assert output.getvalue() == (
             "Dockerfile, line 1: image ubuntu: locked to digest sha256:7804\n"
@@ -270,7 +270,7 @@ class TestDockerfileProcessor:
         processor = DockerfileProcessor(
             resolver, upgrade=True, log=Log(output, verbosity=5)
         )
-        dockerfile = Dockerfile(["FROM ubuntu@sha256:xxx"], name="Dockerfile")
+        dockerfile = Dockerfile(["FROM ubuntu@sha256:xxx"])
         processor.update_dockerfile(dockerfile)
         assert output.getvalue() == (
             "Dockerfile, line 1: image ubuntu@sha256:xxx:"
@@ -283,7 +283,7 @@ class TestDockerfileProcessor:
         processor = DockerfileProcessor(
             resolver, upgrade=True, log=Log(output, verbosity=5)
         )
-        dockerfile = Dockerfile(["FROM ubuntu@sha256:7804"], name="Dockerfile")
+        dockerfile = Dockerfile(["FROM ubuntu@sha256:7804"])
         processor.update_dockerfile(dockerfile)
         assert output.getvalue() == (
             "Dockerfile, line 1: image ubuntu@sha256:7804: up to date\n"

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -204,7 +204,7 @@ class TestDockerfileProcessor:
             "FROM scratch\n",
         ]
 
-    def test_multi_stage(self, resolver):
+    def test_from_multi_stage(self, resolver):
         """Name of previous state is not locked."""
         processor = DockerfileProcessor(resolver)
         dockerfile = Dockerfile(
@@ -218,6 +218,22 @@ class TestDockerfileProcessor:
             "FROM ubuntu@sha256:7804 AS base\n",
             "FROM base\n",
             "CMD echo 'hello world'\n",
+        ]
+
+    def test_from_comments_and_whitespace_preserved(self, resolver):
+        """When an instruction is not changed, its formatting is preserved."""
+        processor = DockerfileProcessor(resolver)
+        dockerfile = Dockerfile(
+            [
+                "FROM \\\n",
+                "    # Example comment\n",
+                "    ubuntu@sha256:xxxx\n",
+            ]
+        )
+        assert processor.update_dockerfile(dockerfile).lines == [
+            "FROM \\\n",
+            "    # Example comment\n",
+            "    ubuntu@sha256:xxxx\n",
         ]
 
     def test_output_new_image_upgrade_false(self, resolver):


### PR DESCRIPTION
- Dockerfile is parsed when updated, not when read.
- The parsing result contains more information about the original file to preserve formatting of instructions not updated.
- Prepares support for more instruction types.